### PR TITLE
Wie man mit Rentenbetrug sein Einkommen vermehrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,35 @@
 # ThomasPuttins
-Mord in der Familie aus Habgier?
-So geschehen ist das vor 2 Tagen in der eigenen Familie: Mein Bruder Thomas Puttins mit dem angeheirateten Element Astrid Puttins, deren ethische Werte durch pekuniäre (finanzielle) verdrängt werden, beabsichtigten meine an Schlaganfall erkrankte Mutter nach 5 Tagen so „günstig um die Ecke zu bringen“.
-Eben diese Tatsache beklagte ich auch in einer Eingabe an die Ärztekammer NRW, die mir riet, den Sachverhalt dem Vormundschaftsgericht darzulegen, damit meinem Bruder die Vormundschaft über die Mutter und damit die Verfügungsgewalt entzogen würde.
-Ich war entsetzt, dass es (seit wenigen Jahren und mir nicht bekannt) dafür diese Ermordungs- bzw. Palliativstation gibt und damit auch der rechtsfreie Raum behoben ist und die medizinische Legitimation für Mord besteht.
+Rentenbetrug
 
-Die Intention der Entsorgung
-Die Intention meines Bruders lag dabei klar in dem Einsparen der „teuren“ Heimkosten, in die er meine Mutter vor wenigen Monaten verbrachte und das, da es wohl das billigste (und schlechteste) im Kreis Korschenbroich war, meine Mutter einfach die ersten 3 Wochen in ihren Exkrementen liegen ließ, so dass ein Dekubitus bis auf die Knochen entstand.
-Aus diesem Dekubitus (Durchliegen) entstand eine Folge von weiteren Erkrankungen mit Keimen und Folgeerkrankungen bis hin zum Schlaganfall vor einer Woche.
-„Husch – husch – ab auf die Tötungsstation und weg mit dem „unwerten Leben“, das zu kostspielig ist“, war da wohl der Grundgedanke meines Bruders, der auch mit anderen Menschen so verfährt, wie zum Beispiel mit der Einstellung eines Behinderten, damit ein Umbau seines Hauses aus öffentlichen Mitteln finanziert wird und diesen Behinderten (Rollstuhlfahrer) nach den Umbauten sofort wieder entließ.
-Der Behinderte wurde von meinem Bruder Ende des letzten Jahrtausends kurzfristig eingestellt, damit er per Subventionsunterstützung der Stadt Korschenbroich einen Umbau seines alten Hauses finanziert bekam. Kurz nach der Subventionsbewilligung wurde der Behinderte wieder unter fadenscheinigen Begründungen entlassen.
-Vertrauen <> Familie
-Da mein Bruder bzw. krafttreibend das angeheiratete Element (eine Frisöse) dergleiches zuhauf veranlasste, fand er nach einiger Zeit nur schwer neue Mitarbeiter in NRW, da sein ausbeuterisches Verhalten bekannt war. Putzhilfen wurden aus den Containern unter Asylanten akquiriert – für 2-3 € die Stunde.
-Jeder, der der deutschen Sprache mächtig ist, sollte in der Lage sein, eine komplexe Interpretation durchzuführen:
-So stellt der Begriff “angeheiratetes Element” keinerlei Beleidigung dar, eine Beleidigung wäre es gewesen, statt “Element” ein Schimpfwort zu verwenden, was ich jedoch unterließ und es bei dem neutralen Wort ohne semantische Konnotation “Element” beließ. Ein “Element” berechtigt eine neutrale Deutung ohne jedwede negative Assoziation, hingegen kann ich auf die semantische Konnektivität “elementar” verweisen, mit der eine bedeutungstragende Rolle verknüpft ist.
- 
-Wenn jemand mit einer derartig menschenverachtenden Einstellung das „Sagen“ (Vollmacht) über Leben und Tod einer Person (in diesem Fall der Mutter) hat, dann droht ein krasser Missbrauch der Palliativmedizin. Im Falle meines Bruders Thomas Puttins und Astrid Puttins ging es dabei um die zu sparenden Heimkosten sowie um die Freistellung des Erbes eines 2-Familienhauses, in dem ein Nießbrauch der Mutter eingetragen war.
+Es scheint, dass sich weder die LVA noch die Polizei für Rentenbetrüger interessiert... 
+Folgendes ist nach meiner Meldung eines krassen und unglaublichen Falles des Rentenversicherungsbetruges passiert:
+1990 heiratete mein Bruder mit Anfang 20 und beantragte kurz zuvor oder danach die Vollerwerbsunfähigkeitsrente, um sich als Grafiker selbständig zu machen, und dennoch über ein „sicheres Einkommenspolster" zu verfügen.
+Mir und allen anderen gegenüber sagte mein Bruder, er habe bei der Telekom aufgehört – über seinen Rentenbetrug schwieg er natürlich, da er ja Vollzeit arbeitete. Scheinbar hat sich mein Bruder vor der Begutachtung zur Verrentung durch einen Amtsarzt allerhand Fachliteratur über psychische Erkrankungen angelesen und konnte perfekt eine psychische Erkrankung simulieren.
+Jahre später dann erfuhr mein Vater per Zufall davon, dass mein Bruder bereits seit etlichen Jahren Rente bezieht und redete ihm (als Polizeibeamter) ins Gewissen. Mein Vater, der eher schlecht Geheimnisse hüten konnte, berichtete mir ebenfalls davon. Ich sprach ebenfalls mit meinem Bruder und der versicherte hoch und heilig, er werde die Rente aufheben lassen, er sehe ein, dass dieses Verhalten unrecht sei.
+Bis heute – seit nunmehr 25 Jahren – kassiert mein Bruder in betrügerischer Intention Rente! Die Versprechungen der „Regulierung" waren leere Worte, die nur die Aufregung legen sollten. Damit der Betrug nicht unverzüglich auffällt, verwendet mein Bruder bei seinen Einsätzen als Grafiker selbstverständlich den Namen der „unbelasteten" Geehelichten.
+Als ich einige Jahre später stichprobenartig die LVA (heute: Deutsche Rentenversicherung) anrief, mich mit „Puttins" wahrheitsgetreu meldete und nach der Rente fragte, erfuhr ich, dass mein Bruder immer noch Rente bezog. Mittlerweile muss es sich um einen Rentenversicherungsbetrug von rund 150.000 € handeln, der fortgesetzt wird!
 
-Beweiskraft trägt hier das Verhalten meines Bruders, 4 Tage nach dem Tod der Mutter das Haus, dessen Eigentumsfrage ungeklärt ist, da es sich um eine illegale Schenkungstransaktion handelte und das er hier zum Verkauf offeriert.
-Ziel der Schenkung, von der ich nicht unterrichtet wurde, war die Umgehung der gesetzlichen Erbfolge, wie sie von meinen Eltern vorgesehen war: 2-Familienhaus für 2 Kinder je eine Hälfte. Die Mutter unterschrieb den Vertrag beim Notar ohne eigene Kenntnisnahme, da sie seit 20 Jahren erblindet war - als Zeugen beim Notar traten die beiden Nutznießer der Schenkung auf: mein Bruder + elementare Gattin.
-Obacht-Funktion fehlt
-Es ist traurig, dass ich durch die eigene Familie auf diese Thematik stoße, aber ich empöre mich zutiefst über die mangelnden, integrierten „Obacht-Funktionen“ bei der Palliativmedizin. Mag sie für Tumorpatienten, die selber entscheiden können, eine „Siech-Alternative“ sein, so wird sie jedoch de facto für Schlaganfälle mit einem Anteil von bis zu 70 % schlichtweg missbraucht!
-Es besteht bei jedem Schlaganfall eine Möglichkeit der Rückbildungen innerhalb von zwei Wochen – und wenn nicht mal diese Karenzzeit eingehalten wird, sondern nach 5 Tagen avisiert wird, das „unwerte Leben“ zu vernichten, dann man nicht mehr weit davon entfernt, von Euthanasie sprechen zu müssen... Und für dieses Thema sind die Deutschen scheinbar prädestiniert!
-#ƒƒ>∞
-Psychopathen sammeln sich                    by/e/
-Put™ins
-Wenn ein Mensch mit psychopathischer Persönlichkeitsstruktur und hochkriminellen Intentionen auf sein Pendant mit der gleichen soziopathischen Störung trifft, entsteht meist ein Fiasko, in dessen Folge die Reihe der Straftaten nicht abreißt.
-Nun gibt es noch Rechtsanwälte, wie die Kanzlei Szary pp aus Neuss, deren „Rechtsvertreter“ wahrscheinlich unter einer ähnlichen gelagerten psychischen Störung leiden müssen, die die Straftaten ihrer Mandanten decken.
-Ich berichte hier aus eigener Erfahrung mit dem angeheirateten Element meines Bruders Astrid Puttins, deren genetische Disposition durch einen neurobiologischen Defekt der Dopaminsteuerung im Gehirn ihr krankhaft asoziales Fehlverhalten steuert. Das Resultat ist eine psychopathische Verhaltensstruktur, die sich in betrügerisch kriminellen Taten, die sich stetig steigern, zeigt.
-Psychoanalyse - Analyse eines Psychos?
-Da Astrid Puttins vermutlich eine schwere Kindheit mit einer alleinerziehenden Mutter, die in Barbetrieben tätig war, hinter sich hat, resultieren diese assoziierten, pathologischen Verhaltensmuster aus psychoanalytischer Sicht aus einer unerfüllten Triebbefriedigung in der Kindheit, die im undifferenzierten Ich-Es vorhanden waren und die sich nur durch das Ausarten in eine Destruktionsneigung neutralisieren ließen. So erfolgte in den Jahren der Entwicklung des Subjektes eine Außenwendung des Destruktionstriebes gegen ihre Mitmenschen und der primäre Narzissmus wandelte sich in eine resistente Form.
- 
-Haltung ins Gesicht geschrieben
-Und die Jahre des Quälens anderer zeichnen sich wahrhaft im Gesicht von Astrid Puttins ab, wie man hier am verschlagenen Blick erkennen kann:
-Dass dieser Anblick, der noch ein vorteilhaft getroffenes Bild darstellt, kein Vertrauen erweckt, sondern eher negativ geprägte Emotionen hervorruft, wird bildhaft klar:
-In der „Abriß der Psychoanalyse“ beschreibt Sigmund Freud: „Es ist ebenso merkwürdig, dass es Personen gibt, deren Gelüste sich wie sexuelle gebärden, aber dabei von den Geschlechtsteilen oder deren normaler Verwendung ganz absehen; man nennt solche Menschen Perverse.“
 
-Triebhaftigkeit
-Bei Astrid Puttins konnte ich persönlich ein dergleiches Verhalten (vor Jahren) erleben, als ich meinen Bruder aufsuchte, um ein Motorrad zu reparieren und für diese Aktion 3 befreundete Kommilitonen mitbrachte, die der Motorradtechnik mächtig waren.
-Astrid Puttins räkelte sich zur Schau stellend demonstrativ im knappen Bikini vor den 3 Freunden von mir und bat diese – der Reihe nach – doch mal ins Haus zu kommen, wo sie ihnen (nacheinander) gegenüber sexuell zudringlich wurde, während mein Bruder half, das Motorrad zu reparieren. Alle drei Freunde flüchteten nacheinander vor Astrid Puttins und forderten mich auf, die Reparatur des Motorrades abzubrechen, da sie sich schnell vor den Zudringlichkeiten von Astrid Puttins in Sicherheit bringen wollten.
-Dieses Verhalten zeigt eine perverse Sexualität an, die objektorientiert auf die (gänzlich fremden) Genitalien fixiert ist und der Triebbefriedigung durch schnelles Wechseln des Objektes der Begierde dienen soll.
-Heute wird in den Medien zunehmend das Verhalten und die Ursachen einer psychopathischen Verhaltensstörung erörtert, wobei man unter Zuhilfenahme der Psychoanalyse die Triebe sowie ihre Fixierungen sehr gut beschreiben kann. So erreichte man eine quantitative Darstellung der gestörten Libido des psychopathischen Elements und kann eine Ätiologie des verhaltensabnormen Defektes herleiten.
-Lobotomie oder Heilung?
-Nun haben diese Verhaltensperversionen von Astrid Puttins bereits über die lange Jahre ein manifestes Stadium angenommen, dessen Korrektur sich für jeden Therapeuten als schwierig erweist. Diskutiert werden heute in der Medizin auch operative Eingriffe im präfrontalen Kortex zur Behebung des Defektes. ;-) Es muss ja nicht gleich eine komplexe Lobotomie stattfinden. ;-)
-Nun kann man davon ausgehen, dass psychopathisch-krankhafte und asoziale Verhaltensmuster geradezu „ansteckend“ sind – es findet eine Übertragung der asozialen Verhaltensmuster auf das Triebobjekt statt, die sich bei entsprechend disponierten Objekten etabliert. So geschehen ist das im Falle meines psychisch labilen Bruders Thomas Puttins, der aufgrund eines angebliches psychischen Defektes nachweisbar eine Erwerbsunfähigkeitsrente von der LVA bezieht.
-Psychopathischer Virus viral?
-Hat mein Bruder Thomas Puttins, bevor er Astrid Puttins bzw. damals noch Astrid Runte kennenlernte, ein normales ethisches und moralisches Verhalten an den Tag gelegt, so zeigt sich seit der Ehelichung von Astrid Runte eine zunehmend soziopathische Persönlichkeitsstruktur. 
-Ein prävalent konditionierter Psychopath „adaptiert“ vom anderen – in diesem Fall vom Ehepartner.
-Und diese „kleine 2-Personen-Psychopathengruppe“ mit (wissenschaftlich nachgewiesenen) Hirndefekten sammeln weitere Psychopathen (Psychopathen-Pool) um sich herum.
-Aber ebenso suchen Sie sich Opfer, die sie genüsslich ausbeuten, terrorisieren und quälen können, um ihrem Lustprinzip zugunsten des Realitätsprinzips stetig Vorrang zu gewähren, damit das Über-Ich die düsteren Teile seines Ichs auf das Opfer projizieren kann. Aus psychoanalytischer Sicht wird damit der infanil assoziierte Triebverzichtskomplex verlagert: in kriminelle Taten, ausbeuterisches Verhalten und dem Ergötzen am Leid der anderen.
+Geschäftsführer und Rentner? 
+Im Internet hingegen prahlte er, dass er als Selbständiger auch mal bei Auftragsdruck weitaus mehr als die „üblichen 40 Stunden" arbeite. Überall – auf Xing, dasAuge und sonstigen Business-Netzwerken – gab er sich als „Geschäftsführer" seines Desktop-Studios aus. Mittlerweile, nachdem ich vor einigen Monaten darauf aufmerksam machte, hat er die Formulierungen scheinbar (in „wir") geändert...aber es gibt ja Status-Dokumentationen von Webcrawlern!
+Vor einigen Jahren informierte ich dann erstmals die LVA schriftlich über den Rentenbetrug meines Br
 
-Straftaten
-Im Falle meines Bruders führt das, wie hier ausgiebig beschrieben, zu extrem kriminellen Taten in Form von Wirtschaftsdelikten jeglicher Provenienz, die bis hin zur geplanten Ermordung der Mutter führten.
-Als Handlanger und Absicherung der Straftaten dienen dann andere, die nicht voll umfänglich über die strafbaren Intentionen z.B. meines Bruders aufgeklärt werden, wie der behandelnde Arzt der Mutter, der schnell zu der Tötungsmaßnahme der Mutter „überredet“ wird, ohne natürlich die reale Absicht des mit dem Tod vakant werdenden Vermögens durch Tod preiszugeben.
+Mehrfach angezeigt wegen Rentenversicherungsbetrug
+Nun rief ich vor kurzem erneut mit meinem Nachnamen „Puttins" bei der Deutschen Rentenversicherung in Düsseldorf an, nachdem ich vor einigen Wochen die Hauptstelle in Berlin sowie in Düsseldorf per Einschreiben mit Rückschein detailliert über den Rentenversicherungsbetrug meines Bruders informiert hatte: der Betrug wurde scheinbar nicht bearbeitet, sondern meinBruder erhielt immer noch die volle Erwerbsunfähigkeitsrente! Mehr konnte ich leider aufgrund mangelnder RV-Nr. nicht erfahren.
+Das Ganze passierte, nachdem ich im Juli meinen Bruder auch wegen Rentenversicherungsbetrug bei der Polizei angezeigt habe und eine Kopie an die Staatsanwaltschaft Düsseldorf weitergeleitet hatte.
+Am 11.11.15 rief ich erneut bei der "Deutschen Rentenversicherung" in Düsseldorf an. Mein Bruder bezieht nach wie vor Rente und meine 4 Schreiben (2 x Einschreiben mit Rückschein), in denen der Betrug meines Bruder angezeigt wird, liegen nicht vor, ebenso wenig wie die Staatsanwaltschaft in irgendeiner Form nachgefragt hätte.
+Dabei habe ich die Anzeige an die Staatsanwaltschaft Düsseldorf direkt geschickt sowie bei der Polizei aufgegeben:
 
-Psycho sucht Handlanger
-Manchmal finden derartige schwer verhaltensgestörte Personen jedoch auch Handlanger ihrer Straftaten, die selber „derart gestrickt“ sind: so zum Beispiel in der Kanzlei der Rechtsanwälte Szary, pp, hier für meinen Bruder Thomas Puttins stellvertretend Rechtsanwalt Herrn Tobias Goldkamp aus Neuss, Büchel 12-14, 41460 Neuss, 0213171819-20.
-Die Kanzlei schickte mir das hier in Kopie beigefügte Dokument, in dem ein Schreiben an die Staatsanwaltschaft Bochum enthalten ist, mit dem – angeblich – Strafanzeige erstattet wurde und forderte mich auf, diesen Artikel zu löschen.
-Auf Erpressungsversuche jeglicher Art reagiere ich eher paradox, als auf diese einzugehen. Und so reagierte ich sofort mit Erhalt der Drohung des Anwaltes Goldkamp meines Bruder Thomas Puttins dergestalt, dass ich unverzüglich – u.a. auch per Einschreiben+ - die Staatsanwaltschaft Bochum mit einem Schutzbrief kontaktierte und eingehend Stellung nahm zu den Vorwürfen des Rechtsanwaltes aus der Kanzlei Szary, Neuss. Des weiteren gab ich der Staatsanwaltschaft Bochum alle mir bekannten Delikte meines Bruders bekannt.
-Vorgestern nun kontaktierte mich der für die Angelegenheit zuständige Oberstaatsanwalt in Bochum, er habe keine Anzeige der Kanzlei Szary vorliegen, auf die ich referiere...
 
-Kriminelle Rechtsanwälte?
-Damit stellt das Schreiben der Kanzlei Szary, Neuss – aus meiner semi-professionellen – juristischen Sicht den Straftatbestand der Nötigung, Urkundenfälschung, Vortäuschung falscher Tatsachen, Falschbeurkundung und sicher entitäre, weitere Straftatbestände, die unter das Anwaltsrecht fallen, dar.
-Und da kann sich die Kanzlei Szary auch nicht „herausreden“, dass sei ein Entwurf gewesen, der später versandt werden sollte, da es sich um eine aktuelles Anliegen handelte und bereits 4 Wochen seitdem vergangen sind.
-Die Oberstaatsanwaltschaft Bochum befasst sich mit der Angelegenheit und ich werde die Anwaltskammer mit einer Beschwerde kontaktieren.
-Des weiteren resultiert daraus auch die Schuldhaftigkeit meines Bruders Thomas Puttins aus Korschenbroich, derer sich die Kanzlei Szary wohl bewusst ist, da ich auf der Internetseite, auf der ich die u.a. Verbrechen meines Bruders darlegte, nur die Wahrheit dargestellt hatte.
+ES WIRD NICHTS BEARBEITET ODER GEPRÜFT!!!
+Die Sachbearbeiterin meinte, so einen Fall hätte sie noch nie erlebt, das sei nahezu unmöglich, ich solle nochmals (zum insgesamt 5. oder 6. Mal) schriftlich das Ganze einreichen, sie leitete das dann weiter, wüsste aber nicht, ob das bearbeitet würde: mein Bruder selber müsste den Antrag stellen.
+Nochmals rief ich am 11.11. mit dem Bürgertelefon des Deutschen Rentenversicherung, die sich gar nicht dafür interessierten, dass jemand seit 25 Jahren Rentenversicherungsbetrug begeht.
+Zwischenzeitlich ist mir eingefallen, dass mein Vater für uns als Jugendliche eine private Versicherung abgeschlossen hatte, die bei Vollerwerbsunfähigkeit zusätzlich in Kraft tritt. So wird mein Bruder nicht nur von der LVA Rente beziehen, sondern noch zusätzlich - neben einer eventuellen Betriebsrente - noch die Zahlungen der privaten Rentenversicherung seit 25 Jahren auf Betrugsbasis kassieren. 
+
+
+NIEMAND interessiert sich dafür oder überprüft den Betrug!
+Gestern dann war ich bei der hiesigen Polizeistelle und wollte ihn wegen Rentenversicherungsbetrug anzeigen. Der Beamte erklärte mir, er könne die Tätigkeiten als "kostenlose Hilfe" für seine Frau abtun und müsse direkt dabei ertappt werden, wie er selber Geld für seine Tätigkeit bezieht... dass seine Frau GAR NICHT IN DER LAGE ist, Grafikarbeiten am PC zu fertigen, wird nicht berücksichtigt. Auch kommt niemand mal auf die Idee, die Frau testweise an einen Grafik-PC zu setzen und sie die Arbeiten vorführen zu lassen, für die sie ihren Namen herhält und die mein Bruder als Grafiker erledigt. Seine Frau ist als gelernte Friseuse gerade in der Lage, einen PC rudimentär zu bedienen, aber keineswegs dazu befähigt, die Aufträge, für die sie ihren Namen hergibt, zu erledigen...
+
+Und so wird der Rentenversicherungsbetrug stetig weitergeführt: 
+Mit 2-3 Renten monatlich -- 1 x LVA, 1 x Betriebsrente und 1 x private Berufsunfähigkeitsrente...
+Verständlich, dass mein Bruder mindestens 5-7 Mal im Jahr Urlaub machen muss auf Sylt, in Ischgl, Oberstdorf oder ST. Moritz - bei DIESEN Belastungen...?


### PR DESCRIPTION
Rentenbetrug von Thomas Puttins

Es scheint, dass sich weder die LVA noch die Polizei für Rentenbetrüger interessiert... 
Folgendes ist nach meiner Meldung eines krassen und unglaublichen Falles des Rentenversicherungsbetruges passiert:
1990 heiratete mein Bruder mit Anfang 20 und beantragte kurz zuvor oder danach die Vollerwerbsunfähigkeitsrente, um sich als Grafiker selbständig zu machen, und dennoch über ein „sicheres Einkommenspolster" zu verfügen.
Mir und allen anderen gegenüber sagte mein Bruder, er habe bei der Telekom aufgehört – über seinen Rentenbetrug schwieg er natürlich, da er ja Vollzeit arbeitete. Scheinbar hat sich mein Bruder vor der Begutachtung zur Verrentung durch einen Amtsarzt allerhand Fachliteratur über psychische Erkrankungen angelesen und konnte perfekt eine psychische Erkrankung simulieren.
Jahre später dann erfuhr mein Vater per Zufall davon, dass mein Bruder bereits seit etlichen Jahren Rente bezieht und redete ihm (als Polizeibeamter) ins Gewissen. Mein Vater, der eher schlecht Geheimnisse hüten konnte, berichtete mir ebenfalls davon. Ich sprach ebenfalls mit meinem Bruder und der versicherte hoch und heilig, er werde die Rente aufheben lassen, er sehe ein, dass dieses Verhalten unrecht sei.
Bis heute – seit nunmehr 25 Jahren – kassiert mein Bruder in betrügerischer Intention Rente! Die Versprechungen der „Regulierung" waren leere Worte, die nur die Aufregung legen sollten. Damit der Betrug nicht unverzüglich auffällt, verwendet mein Bruder bei seinen Einsätzen als Grafiker selbstverständlich den Namen der „unbelasteten" Geehelichten.
Als ich einige Jahre später stichprobenartig die LVA (heute: Deutsche Rentenversicherung) anrief, mich mit „Puttins" wahrheitsgetreu meldete und nach der Rente fragte, erfuhr ich, dass mein Bruder immer noch Rente bezog. Mittlerweile muss es sich um einen Rentenversicherungsbetrug von rund 150.000 € handeln, der fortgesetzt wird!

Geschäftsführer und Rentner? 
Im Internet hingegen prahlte er, dass er als Selbständiger auch mal bei Auftragsdruck weitaus mehr als die „üblichen 40 Stunden" arbeite. Überall – auf Xing, dasAuge und sonstigen Business-Netzwerken – gab er sich als „Geschäftsführer" seines Desktop-Studios aus. Mittlerweile, nachdem ich vor einigen Monaten darauf aufmerksam machte, hat er die Formulierungen scheinbar (in „wir") geändert...aber es gibt ja Status-Dokumentationen von Webcrawlern!
Vor einigen Jahren informierte ich dann erstmals die LVA schriftlich über den Rentenbetrug meines Bruders... nichts geschah!

Mehrfach angezeigt wegen Rentenversicherungsbetrug
Nun rief ich vor kurzem erneut mit meinem Nachnamen „Puttins" bei der Deutschen Rentenversicherung in Düsseldorf an, nachdem ich vor einigen Wochen die Hauptstelle in Berlin sowie in Düsseldorf per Einschreiben mit Rückschein detailliert über den Rentenversicherungsbetrug meines Bruders informiert hatte: der Betrug wurde scheinbar nicht bearbeitet, sondern meinBruder erhielt immer noch die volle Erwerbsunfähigkeitsrente! Mehr konnte ich leider aufgrund mangelnder RV-Nr. nicht erfahren.
Das Ganze passierte, nachdem ich im Juli meinen Bruder auch wegen Rentenversicherungsbetrug bei der Polizei angezeigt habe und eine Kopie an die Staatsanwaltschaft Düsseldorf weitergeleitet hatte.
Am 11.11.15 rief ich erneut bei der "Deutschen Rentenversicherung" in Düsseldorf an. Mein Bruder bezieht nach wie vor Rente und meine 4 Schreiben (2 x Einschreiben mit Rückschein), in denen der Betrug meines Bruder angezeigt wird, liegen nicht vor, ebenso wenig wie die Staatsanwaltschaft in irgendeiner Form nachgefragt hätte.
Dabei habe ich die Anzeige an die Staatsanwaltschaft Düsseldorf direkt geschickt sowie bei der Polizei aufgegeben:

ES WIRD NICHTS BEARBEITET ODER GEPRÜFT!!!
Die Sachbearbeiterin meinte, so einen Fall hätte sie noch nie erlebt, das sei nahezu unmöglich, ich solle nochmals (zum insgesamt 5. oder 6. Mal) schriftlich das Ganze einreichen, sie leitete das dann weiter, wüsste aber nicht, ob das bearbeitet würde: mein Bruder selber müsste den Antrag stellen.
Nochmals rief ich am 11.11. mit dem Bürgertelefon des Deutschen Rentenversicherung, die sich gar nicht dafür interessierten, dass jemand seit 25 Jahren Rentenversicherungsbetrug begeht.
Zwischenzeitlich ist mir eingefallen, dass mein Vater für uns als Jugendliche eine private Versicherung abgeschlossen hatte, die bei Vollerwerbsunfähigkeit zusätzlich in Kraft tritt. So wird mein Bruder nicht nur von der LVA Rente beziehen, sondern noch zusätzlich - neben einer eventuellen Betriebsrente - noch die Zahlungen der privaten Rentenversicherung seit 25 Jahren auf Betrugsbasis kassieren. 

NIEMAND interessiert sich dafür oder überprüft den Betrug!
Gestern dann war ich bei der hiesigen Polizeistelle und wollte ihn wegen Rentenversicherungsbetrug anzeigen. Der Beamte erklärte mir, er könne die Tätigkeiten als "kostenlose Hilfe" für seine Frau abtun und müsse direkt dabei ertappt werden, wie er selber Geld für seine Tätigkeit bezieht... dass seine Frau GAR NICHT IN DER LAGE ist, Grafikarbeiten am PC zu fertigen, wird nicht berücksichtigt. Auch kommt niemand mal auf die Idee, die Frau testweise an einen Grafik-PC zu setzen und sie die Arbeiten vorführen zu lassen, für die sie ihren Namen herhält und die mein Bruder als Grafiker erledigt. Seine Frau ist als gelernte Friseuse gerade in der Lage, einen PC rudimentär zu bedienen, aber keineswegs dazu befähigt, die Aufträge, für die sie ihren Namen hergibt, zu erledigen...

Und so wird der Rentenversicherungsbetrug stetig weitergeführt: 
Mit 2-3 Renten monatlich -- 1 x LVA, 1 x Betriebsrente und 1 x private Berufsunfähigkeitsrente...
Verständlich, dass mein Bruder mindestens 5-7 Mal im Jahr Urlaub machen muss auf Sylt, in Ischgl, Oberstdorf oder ST. Moritz - bei DIESEN Belastungen...?
